### PR TITLE
Expand Project Management Documentation: New Personas/Roles and Checklists

### DIFF
--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -1,81 +1,24 @@
-# OctoAcme Personas
+# Project Management Roles & Personas
 
-This document defines typical roles and responsibilities used in OctoAcme project docs and exercises.
+## New Roles
 
----
+### Stakeholder Liaison
+- **Responsibilities**: Maintains ongoing communication with internal and external stakeholders; captures and relays stakeholder needs, feedback, or concerns; ensures project deliverables align with stakeholder expectations.
+- **Interactions**: Collaborates with Project Manager, Product Owner, and delivery team.
 
-## Developers
+### QA Lead
+- **Responsibilities**: Defines and enforces QA standards; ensures adequate test coverage for all deliverables; manages test teams and reports; drives continuous quality improvements.
+- **Interactions**: Works closely with developers, the Project Manager, and the Release Manager.
 
-### Role Summary
-Developers design, build, test, and deliver software components. They collaborate with product and project leads to implement features that meet acceptance criteria and quality standards.
-
-### Responsibilities
-- Implement features and fixes to meet acceptance criteria
-- Write and maintain tests and documentation
-- Participate in design and code reviews
-- Assist in estimating and planning work
-- Help identify technical risks and propose mitigations
-
-### Goals
-- Deliver reliable, maintainable code
-- Reduce cycle time from idea to production
-- Maintain high test coverage and observability
-
-### Typical Communication
-- Daily standups and sprint planning
-- PR descriptions and code review comments
-- Technical design docs when needed
+### Change Control Coordinator
+- **Responsibilities**: Manages the change request process, logs all changes, evaluates their impact, and ensures change documentation is current.
+- **Interactions**: Works with Project Manager, all delivery teams, and relevant stakeholders.
 
 ---
 
-## Product Managers
+## Role Onboarding Checklist (Template)
 
-### Role Summary
-Product Managers define what should be built to deliver customer and business value. They own the product vision, prioritize the backlog, and measure outcomes.
-
-### Responsibilities
-- Define problem statements and success metrics
-- Prioritize the roadmap and backlog
-- Collaborate with stakeholders and engineering on trade-offs
-- Validate solutions through user research and metrics
-
-### Goals
-- Maximize customer value and impact
-- Make clear, data-driven prioritization decisions
-- Ensure product-market fit and usability
-
-### Typical Communication
-- Weekly alignment with PM and engineering leads
-- Roadmap updates and stakeholder briefings
-- Acceptance criteria and feature specs
-
----
-
-## Project Managers
-
-### Role Summary
-Project Managers coordinate delivery activities, manage schedules, risks, and communications. They enable the team to deliver on commitments efficiently.
-
-### Responsibilities
-- Create and maintain project plans and timelines
-- Manage risks, dependencies, and resource constraints
-- Facilitate meetings (kickoff, planning, retrospectives)
-- Ensure consistent project documentation and status reporting
-- Coordinate cross-team and stakeholder communication
-
-### Goals
-- Deliver projects on time and within scope
-- Minimize unplanned work and escalations
-- Maintain transparency and alignment across stakeholders
-
-### Typical Communication
-- Weekly status updates and stakeholder reports
-- Risk registers and decision logs
-- Coordination via project boards and meeting facilitation
-
----
-
-## How these personas are used in the exercise
-- Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
-- Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
-
+- [ ] Role responsibilities documented and circulated
+- [ ] Expected interactions with stakeholders/other roles are identified
+- [ ] Introductory meeting held with relevant team members
+- [ ] Checklist completion reviewed and signed off


### PR DESCRIPTION
This PR expands the roles and personas documentation in docs/octoacme-roles-and-personas.md.

Adds the following personas:
- Stakeholder Liaison
- QA Lead
- Change Control Coordinator

Also includes a Role Onboarding Checklist template.

Closes #4